### PR TITLE
ci: 添加 Android 构建 workflow + release 签名走 key.properties

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,196 @@
+name: Build Android APK
+
+# Triggered by either:
+#   - pushing a vX.Y.Z tag       → builds + creates a GitHub Release with APKs attached
+#   - manual workflow_dispatch   → builds + uploads APKs as workflow artifact only
+#
+# Required secrets (configure in repo Settings → Secrets and variables → Actions):
+#   KEYSTORE_BASE64    base64-encoded contents of olib-release-key.jks
+#                      generate locally with:  base64 -w 0 android/app/olib-release-key.jks
+#   KEYSTORE_PASSWORD  storePassword from android/key.properties
+#   KEY_PASSWORD       keyPassword from android/key.properties
+#   KEY_ALIAS          keyAlias from android/key.properties (currently "olib")
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual build (for traceability)'
+        required: false
+        default: 'Manual build'
+
+permissions:
+  contents: write  # needed to create a Release on tag pushes
+
+concurrency:
+  group: build-android-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build release APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: '3.44.0'
+          cache: true
+
+      - name: Print toolchain versions
+        run: |
+          flutter --version
+          dart --version
+          java -version
+
+      - name: Read version from pubspec
+        id: pubspec
+        run: |
+          full=$(grep '^version:' pubspec.yaml | sed 's/version:\s*//' | tr -d ' ')
+          version=${full%+*}
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "full=$full" >> "$GITHUB_OUTPUT"
+          echo "Building version: $full"
+
+      - name: Verify tag matches pubspec version
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          TAG: ${{ github.ref_name }}
+          PUBSPEC_VERSION: ${{ steps.pubspec.outputs.version }}
+        run: |
+          expected="v$PUBSPEC_VERSION"
+          if [ "$TAG" != "$expected" ]; then
+            echo "::error::Tag '$TAG' does not match pubspec version '$expected'. Run scripts/bump_version.js first."
+            exit 1
+          fi
+
+      - name: Cache pub
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/*.gradle*', 'android/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Restore signing keystore from secrets
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::KEYSTORE_BASE64 secret is missing. Set it before running this workflow."
+            exit 1
+          fi
+          echo "$KEYSTORE_BASE64" | base64 -d > android/app/olib-release-key.jks
+          # build.gradle.kts reads key.properties from the android/ dir.
+          {
+            echo "storePassword=$KEYSTORE_PASSWORD"
+            echo "keyPassword=$KEY_PASSWORD"
+            echo "keyAlias=$KEY_ALIAS"
+            echo "storeFile=olib-release-key.jks"
+          } > android/key.properties
+          echo "Keystore restored. File sizes:"
+          wc -c android/app/olib-release-key.jks android/key.properties
+
+      - name: Build release APK (universal)
+        run: flutter build apk --release
+
+      - name: Build release APKs (per-ABI split)
+        run: flutter build apk --release --split-per-abi
+
+      - name: Rename APKs and compute checksums
+        id: artifacts
+        run: |
+          cd build/app/outputs/flutter-apk
+          v="${{ steps.pubspec.outputs.version }}"
+
+          # Rename to versioned, project-prefixed filenames
+          [ -f app-release.apk ] && mv app-release.apk "olib-$v-universal.apk"
+          [ -f app-arm64-v8a-release.apk ] && mv app-arm64-v8a-release.apk "olib-$v-arm64-v8a.apk"
+          [ -f app-armeabi-v7a-release.apk ] && mv app-armeabi-v7a-release.apk "olib-$v-armeabi-v7a.apk"
+          [ -f app-x86_64-release.apk ] && mv app-x86_64-release.apk "olib-$v-x86_64.apk"
+
+          # Drop any leftover unsigned/intermediate artifacts
+          rm -f *.apk.sha1 *-debug.apk
+
+          echo "Output files:"
+          ls -lh
+
+          # Single SHA256 manifest covering every shipping APK
+          sha256sum *.apk > sha256sums.txt
+          echo "--- sha256sums.txt ---"
+          cat sha256sums.txt
+
+      - name: Verify keystore signature on universal APK
+        run: |
+          cd build/app/outputs/flutter-apk
+          v="${{ steps.pubspec.outputs.version }}"
+          apk="olib-$v-universal.apk"
+          # build-tools includes apksigner; pick the latest available version
+          apksigner_bin=$(ls -1 "$ANDROID_HOME"/build-tools/*/apksigner 2>/dev/null | sort -V | tail -n1)
+          if [ -z "$apksigner_bin" ]; then
+            echo "::warning::apksigner not found, skipping verification"
+            exit 0
+          fi
+          "$apksigner_bin" verify --print-certs "$apk"
+
+      - name: Cleanup signing material (defence in depth)
+        if: always()
+        run: |
+          rm -f android/app/olib-release-key.jks android/key.properties
+          echo "Signing material removed from runner."
+
+      - name: Upload APK artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: olib-android-v${{ steps.pubspec.outputs.version }}
+          path: |
+            build/app/outputs/flutter-apk/olib-*.apk
+            build/app/outputs/flutter-apk/sha256sums.txt
+          retention-days: 30
+
+      - name: Create GitHub Release (tag pushes only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Olib ${{ github.ref_name }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            build/app/outputs/flutter-apk/olib-*.apk
+            build/app/outputs/flutter-apk/sha256sums.txt

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,8 +1,18 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     // Built-in Kotlin: no longer explicitly apply kotlin-android.
     // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+// Load android/key.properties if present. Absent on fresh clones — release
+// builds then transparently fall back to the debug signing config below.
+val keystoreProperties = Properties().apply {
+    val file = rootProject.file("key.properties")
+    if (file.exists()) load(FileInputStream(file))
 }
 
 android {
@@ -23,9 +33,32 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            val storeFilePath = keystoreProperties["storeFile"] as String?
+            if (storeFilePath != null) {
+                val candidate = file(storeFilePath)
+                if (candidate.exists()) {
+                    storeFile = candidate
+                    storePassword = keystoreProperties["storePassword"] as String?
+                    keyAlias = keystoreProperties["keyAlias"] as String?
+                    keyPassword = keystoreProperties["keyPassword"] as String?
+                }
+            }
+        }
+    }
+
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("debug")
+            // Use release signing when key.properties + keystore are present.
+            // Otherwise sign with the debug key so fresh clones can still
+            // produce installable test builds (do NOT distribute these).
+            val releaseSigning = signingConfigs.getByName("release")
+            signingConfig = if (releaseSigning.storeFile != null) {
+                releaseSigning
+            } else {
+                signingConfigs.getByName("debug")
+            }
             isMinifyEnabled = false
             isShrinkResources = false
         }


### PR DESCRIPTION
- 新增 .github/workflows/build-android.yml：
  - 触发：tag v*.*.* push 或手动 workflow_dispatch
  - tag push 校验 pubspec 版本号必须等于 tag（防 bump_version.js 漏跑）
  - 从 KEYSTORE_BASE64/PASSWORD/KEY_PASSWORD/KEY_ALIAS 4 个 secret 还原 keystore + key.properties，build 完清理
  - flutter build apk --release 双构建（universal + per-ABI split），按版本号重命名为 olib-X.Y.Z-{universal,arm64-v8a,armeabi-v7a,x86_64}.apk
  - apksigner verify 验签 + sha256sums.txt 校验和
  - tag 触发时自动 softprops/action-gh-release 创建 Release 并挂载 APK；手动 dispatch 仅上传为 30 天 artifact
  - pub-cache / gradle-cache 加速、concurrency 取消同 ref 重复任务

- android/app/build.gradle.kts release 改用真正的 release signing：
  - 读 rootProject 的 key.properties；如果 properties 或 .jks 任一缺失，自动回退到 debug 签名，确保 fresh clone 仍能 build（产物不可分发）
  - signingConfigs.create("release") 用 keystoreProperties 4 字段